### PR TITLE
직업,스킬명,스킬쿨타임 플래이스홀더 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:$fabricLoaderVersion"
     modImplementation "net.fabricmc.fabric-api:fabric-api:$fabricApiVersion"
     modImplementation "eu.pb4:polymer-core:$polymerVersion"
+    modImplementation(include("eu.pb4:placeholder-api:$placeholderApiVersion"))
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,4 @@ fabricLoomVersion=1.7-SNAPSHOT
 minecraftVersion=1.21.1
 polymerVersion=0.9.16+1.21.1
 yarnVersion=1.21.1+build.3
+placeholderApiVersion=2.4.1+1.21

--- a/src/main/java/org/gjdd/batoru/BatoruMod.java
+++ b/src/main/java/org/gjdd/batoru/BatoruMod.java
@@ -4,6 +4,7 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import org.gjdd.batoru.command.JobCommand;
 import org.gjdd.batoru.command.SkillCommand;
+import org.gjdd.batoru.compat.BatoruPlaceholder;
 import org.gjdd.batoru.component.BatoruDataComponentTypes;
 import org.gjdd.batoru.config.BatoruConfigManager;
 import org.gjdd.batoru.registry.BatoruRegistries;
@@ -20,5 +21,6 @@ public final class BatoruMod implements ModInitializer {
         BatoruConfigManager.INSTANCE.loadConfig();
         BatoruRegistries.register();
         BatoruRegistryKeys.register();
+        BatoruPlaceholder.register();
     }
 }

--- a/src/main/java/org/gjdd/batoru/compat/BatoruPlaceholder.java
+++ b/src/main/java/org/gjdd/batoru/compat/BatoruPlaceholder.java
@@ -27,7 +27,7 @@ public class BatoruPlaceholder {
             if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
 
             var skillmap = e.getJob().value().getSkillMap();
-            if (skillmap.get(SkillSlot.NORMAL_1) == null) return PlaceholderResult.invalid("No Skill!");
+            if (skillmap.get(SkillSlot.NORMAL_1) == null) return PlaceholderResult.value("None");
 
             return PlaceholderResult.value(skillmap.get(SkillSlot.NORMAL_1).value().getName());
         });
@@ -40,7 +40,7 @@ public class BatoruPlaceholder {
             if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
 
             var skillmap = e.getJob().value().getSkillMap();
-            if (skillmap.get(SkillSlot.NORMAL_2) == null) return PlaceholderResult.invalid("No Skill!");
+            if (skillmap.get(SkillSlot.NORMAL_2) == null) return PlaceholderResult.value("None");
 
             return PlaceholderResult.value(skillmap.get(SkillSlot.NORMAL_2).value().getName());
         });
@@ -53,7 +53,7 @@ public class BatoruPlaceholder {
             if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
 
             var skillmap = e.getJob().value().getSkillMap();
-            if (skillmap.get(SkillSlot.NORMAL_3) == null) return PlaceholderResult.invalid("No Skill!");
+            if (skillmap.get(SkillSlot.NORMAL_3) == null) return PlaceholderResult.value("None");
 
             return PlaceholderResult.value(skillmap.get(SkillSlot.NORMAL_3).value().getName());
         });
@@ -66,11 +66,12 @@ public class BatoruPlaceholder {
             if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
 
             var skillmap = e.getJob().value().getSkillMap();
-            if (skillmap.get(SkillSlot.ULTIMATE) == null) return PlaceholderResult.invalid("No Skill!");
+            if (skillmap.get(SkillSlot.ULTIMATE) == null) return PlaceholderResult.value("None");
 
             return PlaceholderResult.value(skillmap.get(SkillSlot.ULTIMATE).value().getName());
         });
 
+        //쿨다운 초 표현
         Placeholders.register(Identifier.of("batoru", "skill_normal_1_cooldown"), (ctx, arg) -> {
             if (!ctx.hasEntity()) return PlaceholderResult.invalid("No Entity!");
             if (!ctx.entity().isLiving()) return PlaceholderResult.invalid("Not LivingEntity!");
@@ -79,9 +80,9 @@ public class BatoruPlaceholder {
             if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
 
             var skillmap = e.getJob().value().getSkillMap();
-            if (skillmap.get(SkillSlot.NORMAL_1) == null) return PlaceholderResult.invalid("No Skill!");
+            if (skillmap.get(SkillSlot.NORMAL_1) == null) return PlaceholderResult.value("0");
 
-            return PlaceholderResult.value(String.valueOf(e.getSkillCooldown(skillmap.get(SkillSlot.NORMAL_1))));
+            return PlaceholderResult.value(String.valueOf(Math.ceil((double) e.getSkillCooldown(skillmap.get(SkillSlot.NORMAL_1))/20)));
         });
 
         Placeholders.register(Identifier.of("batoru", "skill_normal_2_cooldown"), (ctx, arg) -> {
@@ -92,9 +93,9 @@ public class BatoruPlaceholder {
             if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
 
             var skillmap = e.getJob().value().getSkillMap();
-            if (skillmap.get(SkillSlot.NORMAL_2) == null) return PlaceholderResult.invalid("No Skill!");
+            if (skillmap.get(SkillSlot.NORMAL_2) == null) return PlaceholderResult.value("0");
 
-            return PlaceholderResult.value(String.valueOf(e.getSkillCooldown(skillmap.get(SkillSlot.NORMAL_2))));
+            return PlaceholderResult.value(String.valueOf(Math.ceil((double) e.getSkillCooldown(skillmap.get(SkillSlot.NORMAL_2))/20)));
         });
 
         Placeholders.register(Identifier.of("batoru", "skill_normal_3_cooldown"), (ctx, arg) -> {
@@ -105,9 +106,9 @@ public class BatoruPlaceholder {
             if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
 
             var skillmap = e.getJob().value().getSkillMap();
-            if (skillmap.get(SkillSlot.NORMAL_3) == null) return PlaceholderResult.invalid("No Skill!");
+            if (skillmap.get(SkillSlot.NORMAL_3) == null) return PlaceholderResult.value("0");
 
-            return PlaceholderResult.value(String.valueOf(e.getSkillCooldown(skillmap.get(SkillSlot.NORMAL_3))));
+            return PlaceholderResult.value(String.valueOf(Math.ceil((double) e.getSkillCooldown(skillmap.get(SkillSlot.NORMAL_3))/20)));
         });
 
         Placeholders.register(Identifier.of("batoru", "skill_ultimate_cooldown"), (ctx, arg) -> {
@@ -118,7 +119,60 @@ public class BatoruPlaceholder {
             if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
 
             var skillmap = e.getJob().value().getSkillMap();
-            if (skillmap.get(SkillSlot.ULTIMATE) == null) return PlaceholderResult.invalid("No Skill!");
+            if (skillmap.get(SkillSlot.ULTIMATE) == null) return PlaceholderResult.value("0");
+
+            return PlaceholderResult.value(String.valueOf(Math.ceil((double) e.getSkillCooldown(skillmap.get(SkillSlot.ULTIMATE))/20)));
+        });
+
+        //쿨다운 틱 표현
+        Placeholders.register(Identifier.of("batoru", "skill_normal_1_cooldown_tick"), (ctx, arg) -> {
+            if (!ctx.hasEntity()) return PlaceholderResult.invalid("No Entity!");
+            if (!ctx.entity().isLiving()) return PlaceholderResult.invalid("Not LivingEntity!");
+
+            var e = (LivingEntity) ctx.entity();
+            if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
+
+            var skillmap = e.getJob().value().getSkillMap();
+            if (skillmap.get(SkillSlot.NORMAL_1) == null) return PlaceholderResult.value("0");
+
+            return PlaceholderResult.value(String.valueOf(e.getSkillCooldown(skillmap.get(SkillSlot.NORMAL_1))));
+        });
+
+        Placeholders.register(Identifier.of("batoru", "skill_normal_2_cooldown_tick"), (ctx, arg) -> {
+            if (!ctx.hasEntity()) return PlaceholderResult.invalid("No Entity!");
+            if (!ctx.entity().isLiving()) return PlaceholderResult.invalid("Not LivingEntity!");
+
+            var e = (LivingEntity) ctx.entity();
+            if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
+
+            var skillmap = e.getJob().value().getSkillMap();
+            if (skillmap.get(SkillSlot.NORMAL_2) == null) return PlaceholderResult.value("0");
+
+            return PlaceholderResult.value(String.valueOf(e.getSkillCooldown(skillmap.get(SkillSlot.NORMAL_2))));
+        });
+
+        Placeholders.register(Identifier.of("batoru", "skill_normal_3_cooldown_tick"), (ctx, arg) -> {
+            if (!ctx.hasEntity()) return PlaceholderResult.invalid("No Entity!");
+            if (!ctx.entity().isLiving()) return PlaceholderResult.invalid("Not LivingEntity!");
+
+            var e = (LivingEntity) ctx.entity();
+            if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
+
+            var skillmap = e.getJob().value().getSkillMap();
+            if (skillmap.get(SkillSlot.NORMAL_3) == null) return PlaceholderResult.value("0");
+
+            return PlaceholderResult.value(String.valueOf(e.getSkillCooldown(skillmap.get(SkillSlot.NORMAL_3))));
+        });
+
+        Placeholders.register(Identifier.of("batoru", "skill_ultimate_cooldown_tick"), (ctx, arg) -> {
+            if (!ctx.hasEntity()) return PlaceholderResult.invalid("No Entity!");
+            if (!ctx.entity().isLiving()) return PlaceholderResult.invalid("Not LivingEntity!");
+
+            var e = (LivingEntity) ctx.entity();
+            if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
+
+            var skillmap = e.getJob().value().getSkillMap();
+            if (skillmap.get(SkillSlot.ULTIMATE) == null) return PlaceholderResult.value("0");
 
             return PlaceholderResult.value(String.valueOf(e.getSkillCooldown(skillmap.get(SkillSlot.ULTIMATE))));
         });

--- a/src/main/java/org/gjdd/batoru/compat/BatoruPlaceholder.java
+++ b/src/main/java/org/gjdd/batoru/compat/BatoruPlaceholder.java
@@ -1,0 +1,126 @@
+package org.gjdd.batoru.compat;
+
+import eu.pb4.placeholders.api.PlaceholderResult;
+import eu.pb4.placeholders.api.Placeholders;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import org.gjdd.batoru.job.SkillSlot;
+
+public class BatoruPlaceholder {
+    public static void register() {
+        Placeholders.register(Identifier.of("batoru", "job"), (ctx, arg) -> {
+            if (!ctx.hasEntity()) return PlaceholderResult.invalid("No Entity!");
+            if (!ctx.entity().isLiving()) return PlaceholderResult.invalid("Not LivingEntity!");
+
+            var e = (LivingEntity) ctx.entity();
+            if (e.getJob() == null) return PlaceholderResult.value("None");
+
+            return PlaceholderResult.value(e.getJob().value().getName());
+        });
+
+        Placeholders.register(Identifier.of("batoru", "skill_normal_1"), (ctx, arg) -> {
+            if (!ctx.hasEntity()) return PlaceholderResult.invalid("No Entity!");
+            if (!ctx.entity().isLiving()) return PlaceholderResult.invalid("Not LivingEntity!");
+
+            var e = (LivingEntity) ctx.entity();
+            if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
+
+            var skillmap = e.getJob().value().getSkillMap();
+            if (skillmap.get(SkillSlot.NORMAL_1) == null) return PlaceholderResult.invalid("No Skill!");
+
+            return PlaceholderResult.value(skillmap.get(SkillSlot.NORMAL_1).value().getName());
+        });
+
+        Placeholders.register(Identifier.of("batoru", "skill_normal_2"), (ctx, arg) -> {
+            if (!ctx.hasEntity()) return PlaceholderResult.invalid("No Entity!");
+            if (!ctx.entity().isLiving()) return PlaceholderResult.invalid("Not LivingEntity!");
+
+            var e = (LivingEntity) ctx.entity();
+            if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
+
+            var skillmap = e.getJob().value().getSkillMap();
+            if (skillmap.get(SkillSlot.NORMAL_2) == null) return PlaceholderResult.invalid("No Skill!");
+
+            return PlaceholderResult.value(skillmap.get(SkillSlot.NORMAL_2).value().getName());
+        });
+
+        Placeholders.register(Identifier.of("batoru", "skill_normal_3"), (ctx, arg) -> {
+            if (!ctx.hasEntity()) return PlaceholderResult.invalid("No Entity!");
+            if (!ctx.entity().isLiving()) return PlaceholderResult.invalid("Not LivingEntity!");
+
+            var e = (LivingEntity) ctx.entity();
+            if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
+
+            var skillmap = e.getJob().value().getSkillMap();
+            if (skillmap.get(SkillSlot.NORMAL_3) == null) return PlaceholderResult.invalid("No Skill!");
+
+            return PlaceholderResult.value(skillmap.get(SkillSlot.NORMAL_3).value().getName());
+        });
+
+        Placeholders.register(Identifier.of("batoru", "skill_ultimate"), (ctx, arg) -> {
+            if (!ctx.hasEntity()) return PlaceholderResult.invalid("No Entity!");
+            if (!ctx.entity().isLiving()) return PlaceholderResult.invalid("Not LivingEntity!");
+
+            var e = (LivingEntity) ctx.entity();
+            if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
+
+            var skillmap = e.getJob().value().getSkillMap();
+            if (skillmap.get(SkillSlot.ULTIMATE) == null) return PlaceholderResult.invalid("No Skill!");
+
+            return PlaceholderResult.value(skillmap.get(SkillSlot.ULTIMATE).value().getName());
+        });
+
+        Placeholders.register(Identifier.of("batoru", "skill_normal_1_cooldown"), (ctx, arg) -> {
+            if (!ctx.hasEntity()) return PlaceholderResult.invalid("No Entity!");
+            if (!ctx.entity().isLiving()) return PlaceholderResult.invalid("Not LivingEntity!");
+
+            var e = (LivingEntity) ctx.entity();
+            if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
+
+            var skillmap = e.getJob().value().getSkillMap();
+            if (skillmap.get(SkillSlot.NORMAL_1) == null) return PlaceholderResult.invalid("No Skill!");
+
+            return PlaceholderResult.value(String.valueOf(e.getSkillCooldown(skillmap.get(SkillSlot.NORMAL_1))));
+        });
+
+        Placeholders.register(Identifier.of("batoru", "skill_normal_2_cooldown"), (ctx, arg) -> {
+            if (!ctx.hasEntity()) return PlaceholderResult.invalid("No Entity!");
+            if (!ctx.entity().isLiving()) return PlaceholderResult.invalid("Not LivingEntity!");
+
+            var e = (LivingEntity) ctx.entity();
+            if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
+
+            var skillmap = e.getJob().value().getSkillMap();
+            if (skillmap.get(SkillSlot.NORMAL_2) == null) return PlaceholderResult.invalid("No Skill!");
+
+            return PlaceholderResult.value(String.valueOf(e.getSkillCooldown(skillmap.get(SkillSlot.NORMAL_2))));
+        });
+
+        Placeholders.register(Identifier.of("batoru", "skill_normal_3_cooldown"), (ctx, arg) -> {
+            if (!ctx.hasEntity()) return PlaceholderResult.invalid("No Entity!");
+            if (!ctx.entity().isLiving()) return PlaceholderResult.invalid("Not LivingEntity!");
+
+            var e = (LivingEntity) ctx.entity();
+            if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
+
+            var skillmap = e.getJob().value().getSkillMap();
+            if (skillmap.get(SkillSlot.NORMAL_3) == null) return PlaceholderResult.invalid("No Skill!");
+
+            return PlaceholderResult.value(String.valueOf(e.getSkillCooldown(skillmap.get(SkillSlot.NORMAL_3))));
+        });
+
+        Placeholders.register(Identifier.of("batoru", "skill_ultimate_cooldown"), (ctx, arg) -> {
+            if (!ctx.hasEntity()) return PlaceholderResult.invalid("No Entity!");
+            if (!ctx.entity().isLiving()) return PlaceholderResult.invalid("Not LivingEntity!");
+
+            var e = (LivingEntity) ctx.entity();
+            if (e.getJob() == null) return PlaceholderResult.invalid("No Job!");
+
+            var skillmap = e.getJob().value().getSkillMap();
+            if (skillmap.get(SkillSlot.ULTIMATE) == null) return PlaceholderResult.invalid("No Skill!");
+
+            return PlaceholderResult.value(String.valueOf(e.getSkillCooldown(skillmap.get(SkillSlot.ULTIMATE))));
+        });
+    }
+}


### PR DESCRIPTION
https://github.com/Patbox/TextPlaceholderAPI?tab=readme-ov-file

이 API를 사용했습니다
`batoru:job`: 직업 이름
`batoru:skill_normal_1`: 1번 스킬이름
`batoru:skill_normal_2`: 2번 스킬이름
`batoru:skill_normal_3`: 3번 스킬이름
`batoru:skill_ultimate`:  4번 스킬이름
`batoru:skill_normal_1_cooldown`: 1번 스킬 쿨다운
`batoru:skill_normal_2_cooldown`: 2번 스킬 쿨다운
`batoru:skill_normal_3_cooldown`: 3번 스킬 쿨다운
`batoru:skill_ultimate_cooldown`: 4번 스킬 쿨다운